### PR TITLE
update maven central repository to https

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
   <repositories>
     <repository>
       <id>central</id>
-      <url>http://repo1.maven.org/maven2</url>
+      <url>https://repo1.maven.org/maven2</url>
     </repository>
     <repository>
       <id>bintray</id>


### PR DESCRIPTION
The Maven Central Repository is moved to https ([source](https://blog.sonatype.com/central-repository-moving-to-https)). I updated it in the `pom.xml`. Fixes #1 